### PR TITLE
Append signoff if text already exists

### DIFF
--- a/content.js
+++ b/content.js
@@ -9,19 +9,25 @@ chrome.storage.local.get({
 }, function (items) {
     if (items.name && items.email) {
         var signoff = "Signed-off-by: " + items.name + " <" + items.email + ">"
+        function appendSignoff(e) {
+            if (e.value !== '') {
+                // Don't append if the last line is already the same signoff
+                s = e.value.split('\n')
+                lastLine = s[s.length-1]
+                if (lastLine !== signoff) {
+                    e.value += '\n\n' + signoff
+                }
+            } else {
+                e.value = signoff
+            }
+        }
         // Standard commit message
         cdt = document.getElementById('commit-description-textarea')
         if (cdt) {
-            // Add a newline separator only if text already exists
-            sep = cdt.value == '' ? '' : "\n\n"
-            // Append
-            cdt.value += sep + signoff;
+            appendSignoff(cdt)
         }
         // Suggested changes commit message
         // ref: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request
-        document.getElementsByName('commit_message').forEach(function(v,i,o){
-            sep = o[i].value == '' ? '' : "\n\n"
-            o[i].value += sep + this
-        }, signoff);
+        document.getElementsByName('commit_message').forEach(appendSignoff);
     }
 });

--- a/content.js
+++ b/content.js
@@ -12,10 +12,16 @@ chrome.storage.local.get({
         // Standard commit message
         cdt = document.getElementById('commit-description-textarea')
         if (cdt) {
-            cdt.value = signoff;
+            // Add a newline separator only if text already exists
+            sep = cdt.value == '' ? '' : "\n\n"
+            // Append
+            cdt.value += sep + signoff;
         }
         // Suggested changes commit message
         // ref: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request
-        document.getElementsByName('commit_message').forEach(function(v,i,o){o[i].value = this}, signoff);
+        document.getElementsByName('commit_message').forEach(function(v,i,o){
+            sep = o[i].value == '' ? '' : "\n\n"
+            o[i].value += sep + this
+        }, signoff);
     }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "DCO GitHub UI",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "DCO signoff for GitHub UI",
     "options_ui": {
         "page": "options.html",


### PR DESCRIPTION
Alternative approach to #11 

This is safer, either way.

It does still add a signoff to merge commits, but now it only appends to whatever was already there. The reason is it's not easy to tell if the user had selected a merge commit or squash and merge (rebase and merge doesn't have a commit message option).